### PR TITLE
Remove regex and lazy_static deps

### DIFF
--- a/spec/Cargo.toml
+++ b/spec/Cargo.toml
@@ -10,8 +10,6 @@ default = ["serde"]
 [dependencies]
 chrono = { version = "0.4.7", features = ["serde"] }
 hex = "0.3.2"
-lazy_static = "1.3.0"
-regex = "1.2.1"
 sha2 = "0.8.0"
 serde = { version = "1.0.98", features = ["derive"], optional = true }
 url = { version = "2.1.0", features = ["serde"] }


### PR DESCRIPTION
.. and implement digest format validation without them.

This change decreases the compilation time as follows:

| branch            | default features  | compile time [s]  |
| :---------------- | :---------------- | :---------------- |
| master            | on                | 43.51             |
| remove-regex-dep  | on                | 30.16             |
| master            | off               | 41.16             |
| remove-regex-dep  | off               | 30.39             |
